### PR TITLE
Fix: accept android-arm64-gplay and other platform variants

### DIFF
--- a/.github/workflows/integration-upload-android-arm64-gplay-prod.yml
+++ b/.github/workflows/integration-upload-android-arm64-gplay-prod.yml
@@ -1,0 +1,33 @@
+name: "Integration: Upload Android ARM64 GPlay (Prod)"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download APK
+        shell: bash
+        run: |
+          set -euo pipefail
+          APK_URL="https://jwvmttqclexlhnhfxuyq.supabase.co/storage/v1/object/public/test_app_builds/wikipedia.apk"
+          echo "Downloading APK from ${APK_URL}"
+          curl --fail --location --silent --show-error "${APK_URL}" --output wikipedia.apk
+          test -s wikipedia.apk
+
+      - name: Upload to Autosana (prod)
+        uses: ./
+        with:
+          api-key: ${{ secrets.AUTOSANA_KEY }}
+          name: Wikipedia
+          bundle-id: org.wikipedia
+          platform: android-arm64-gplay
+          build-path: wikipedia.apk

--- a/.github/workflows/integration-upload-android-arm64-gplay-staging.yml
+++ b/.github/workflows/integration-upload-android-arm64-gplay-staging.yml
@@ -1,0 +1,34 @@
+name: "Integration: Upload Android ARM64 GPlay (Staging)"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download APK
+        shell: bash
+        run: |
+          set -euo pipefail
+          APK_URL="https://jwvmttqclexlhnhfxuyq.supabase.co/storage/v1/object/public/test_app_builds/wikipedia.apk"
+          echo "Downloading APK from ${APK_URL}"
+          curl --fail --location --silent --show-error "${APK_URL}" --output wikipedia.apk
+          test -s wikipedia.apk
+
+      - name: Upload to Autosana (staging)
+        uses: ./
+        with:
+          api-key: ${{ secrets.AUTOSANA_STAGING_KEY }}
+          api-url: https://staging.autosana.ai
+          name: Wikipedia
+          bundle-id: org.wikipedia
+          platform: android-arm64-gplay
+          build-path: wikipedia.apk

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ if [ "$PLATFORM" = "web" ]; then
     echo "   Provided: '$URL'"
     exit 1
   fi
-elif [ "$PLATFORM" = "android" ] || [ "$PLATFORM" = "ios" ]; then
+elif echo "$PLATFORM" | grep -qE '^(android|ios)'; then
   echo "📱 Mobile platform detected: $PLATFORM"
   echo "🔍 Checking mobile-specific environment variables..."
   echo "   AUTOSANA_KEY: ${AUTOSANA_KEY:0:10}... (${#AUTOSANA_KEY} chars)"
@@ -80,7 +80,7 @@ elif [ "$PLATFORM" = "android" ] || [ "$PLATFORM" = "ios" ]; then
     exit 1
   fi
 else
-  echo "❌ ERROR: Invalid platform '$PLATFORM'. Must be 'android', 'ios', or 'web'."
+  echo "❌ ERROR: Invalid platform '$PLATFORM'. Must start with 'android' or 'ios', or be 'web'."
   exit 1
 fi
 

--- a/tests/input_validation.bats
+++ b/tests/input_validation.bats
@@ -145,6 +145,13 @@ setup() {
     assert_output --partial "All required environment variables are set"
 }
 
+@test "android-arm64-gplay platform passes validation" {
+    export PLATFORM="android-arm64-gplay"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "All required environment variables are set"
+}
+
 @test "valid ios inputs pass validation" {
     export PLATFORM="ios"
     run bash "$ENTRYPOINT"


### PR DESCRIPTION
## Summary
- Change platform validation from exact match (`== "android"` / `== "ios"`) to prefix match (`grep -qE '^(android|ios)'`) so variants like `android-arm64-gplay` are accepted
- Add test case for `android-arm64-gplay` platform validation

## Context
The strict platform validation added in `a574068` (Feb 11 — "add support for web urls") broke customers using `android-arm64-gplay` as their platform. They were forced to switch to `android`, which created a duplicate app record with no CI/CD automations attached.

## Test plan
- [ ] `input_validation.bats` passes, including new `android-arm64-gplay` test
- [ ] Customer (Issen) can set platform back to `android-arm64-gplay` and CI runs trigger

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading Android ARM64 builds to Google Play.
  * Improved platform detection to support extended platform variants.

* **Tests**
  * Added validation test coverage for the android-arm64-gplay platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->