### PR TITLE
docs: add optional autosana-ci action inputs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Shared optional inputs:
 - `name`: Display name for the app
 - `environment`: Environment name such as `staging` or `production`
 - `api-url`: Override the API base URL. Defaults to `https://backend.autosana.ai`
-- `variables`: Key-value variables exposed to flow instructions via `${env:KEY}`. Accepts either `KEY1=VALUE1,KEY2=VALUE2` or multiline `KEY=VALUE` pairs.
+- `variables`: Key-value variables exposed to flow instructions via `${env:KEY}`. Use `KEY1=VALUE1,KEY2=VALUE2`.
 - `suite-ids`: Comma-separated suite UUIDs to run after upload
 - `flow-ids`: Comma-separated flow UUIDs to run after upload
 
@@ -51,8 +51,6 @@ Platform-specific required inputs:
     build-path: build/app/outputs/flutter-apk/app-release.apk
     name: Example App
     environment: staging
-    variables: |
-      PR_NUMBER=${{ github.event.pull_request.number }}
-      BRANCH=${{ github.head_ref }}
+    variables: "TEST_ACCOUNT=qa-smoke,CHECKOUT_VARIANT=control"
     flow-ids: "uuid-1,uuid-2"
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,58 @@
 # Autosana CI/CD Github Action
-CI integration to upload new builds and trigger flows from github workflows
 
-```
+CI integration to upload new builds and trigger flows from GitHub workflows.
+
+## Basic usage
+
+```yaml
 - uses: autosana/autosana-ci@main
   with:
     api-key: ${{ secrets.AUTOSANA_KEY }}
-    bundle-id: com.example.app
     platform: android
+    bundle-id: com.example.app
     build-path: build/app/outputs/flutter-apk/app-release.apk
+```
+
+## Web usage
+
+```yaml
+- uses: autosana/autosana-ci@main
+  with:
+    api-key: ${{ secrets.AUTOSANA_KEY }}
+    platform: web
+    app-id: my-web-app
+    url: https://preview.example.com
+```
+
+## Optional inputs
+
+Shared optional inputs:
+
+- `name`: Display name for the app
+- `environment`: Environment name such as `staging` or `production`
+- `api-url`: Override the API base URL. Defaults to `https://backend.autosana.ai`
+- `variables`: Key-value variables exposed to flow instructions via `${env:KEY}`. Accepts either `KEY1=VALUE1,KEY2=VALUE2` or multiline `KEY=VALUE` pairs.
+- `suite-ids`: Comma-separated suite UUIDs to run after upload
+- `flow-ids`: Comma-separated flow UUIDs to run after upload
+
+Platform-specific required inputs:
+
+- Mobile (`android` or `ios`): `bundle-id`, `build-path`
+- Web (`web`): `app-id`, `url`
+
+## Example with optional inputs
+
+```yaml
+- uses: autosana/autosana-ci@main
+  with:
+    api-key: ${{ secrets.AUTOSANA_KEY }}
+    platform: android
+    bundle-id: com.example.app
+    build-path: build/app/outputs/flutter-apk/app-release.apk
+    name: Example App
+    environment: staging
+    variables: |
+      PR_NUMBER=${{ github.event.pull_request.number }}
+      BRANCH=${{ github.head_ref }}
+    flow-ids: "uuid-1,uuid-2"
 ```

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
 
   # Build variables (optional - passed to flow instructions via ${env:KEY})
   variables:
-    description: "Key-value variables to pass to flow instructions (format: KEY1=VALUE1,KEY2=VALUE2 or multiline KEY=VALUE pairs)"
+    description: "Key-value variables to pass to flow instructions (format: KEY1=VALUE1,KEY2=VALUE2)"
     required: false
 
   # Flow execution inputs (optional - provide to run flows after upload)


### PR DESCRIPTION
## Summary
- document shared optional action inputs in the `autosana-ci` README
- add examples for web usage and variables plus post-upload flow execution

## Test plan
- [x] Review README diff locally
- [ ] Confirm rendered markdown in GitHub PR preview

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README into full GitHub Actions usage docs with clearer workflow wording and structure.
  * Added platform-specific YAML examples for Android and Web, showing required inputs and sample optional fields.
  * Clarified optional inputs with an example (including name, environment, variables, flow IDs).
  * Updated variables input description to require comma-separated KEY=VALUE pairs (multiline pairs no longer supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->