### PR TITLE
fix: increase flows/run curl timeout from 60s to 300s

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -548,7 +548,7 @@ echo ""
 
 RESPONSE=$(curl -s -X POST "$API_BASE_URL/api/v1/flows/run" \
   --connect-timeout 30 \
-  --max-time 60 \
+  --max-time 300 \
   -H "X-API-Key: $AUTOSANA_KEY" \
   -H "Content-Type: application/json" \
   -d "$RUN_PAYLOAD" \


### PR DESCRIPTION
## Summary

- Increases `--max-time` on the `POST /api/v1/flows/run` curl call from 60s to 300s
- Fixes exit code 28 (curl timeout) when triggering large batches of flows + suites via CI

## Context

Reported by Ziina (Georgii): when passing both `flow-ids` (58 regression flows) and `suite-ids` (1 suite) together, the action failed with exit code 28 without waiting for results.

**Root cause confirmed via Logfire**: the `/api/v1/flows/run` endpoint creates `flow_group_run`s sequentially (one per flow ID so they dispatch in parallel). For 59 total runs, this took 63.3s — just over the 60s curl timeout. The server returned HTTP 200 successfully, but curl had already given up.

The O(n) sequential creation is a known optimization target (each call repeats ~6 identical DB lookups), but bumping the timeout unblocks CI users immediately.

## Test plan

- [ ] Verify Ziina's regression workflow (58 flows + 1 suite) completes the trigger step without exit code 28
- [ ] Confirm polling phase starts and tracks all flow runs correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased timeout duration for flow execution requests, allowing longer-running operations to complete successfully without premature termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->