### PR TITLE
feat: add browser input for web flow runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Shared optional inputs:
 - `variables`: Key-value variables exposed to flow instructions via `${env:KEY}`. Use `KEY1=VALUE1,KEY2=VALUE2`.
 - `suite-ids`: Comma-separated suite UUIDs to run after upload
 - `flow-ids`: Comma-separated flow UUIDs to run after upload
-- `web-browser`: Web only. Playwright engine to run on — `chromium` (default), `firefox`, or `edge`. Aliases accepted: `chrome` → `chromium`, `msedge` → `edge`. Ignored for mobile.
+- `web-browser`: Web only. Playwright engine to run on — `chrome` (default, real Google Chrome with proprietary codecs and DRM), `chromium` (bundled Chromium engine, no codecs / DRM), `firefox`, or `edge`. Aliases accepted: `msedge` → `edge`. Ignored for mobile.
 
 Platform-specific required inputs:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Shared optional inputs:
 - `variables`: Key-value variables exposed to flow instructions via `${env:KEY}`. Use `KEY1=VALUE1,KEY2=VALUE2`.
 - `suite-ids`: Comma-separated suite UUIDs to run after upload
 - `flow-ids`: Comma-separated flow UUIDs to run after upload
-- `browser`: Web only. Playwright engine to run on — `chromium` (default), `firefox`, or `edge`. Aliases accepted: `chrome` → `chromium`, `msedge` → `edge`. Ignored for mobile.
+- `web-browser`: Web only. Playwright engine to run on — `chromium` (default), `firefox`, or `edge`. Aliases accepted: `chrome` → `chromium`, `msedge` → `edge`. Ignored for mobile.
 
 Platform-specific required inputs:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Shared optional inputs:
 - `variables`: Key-value variables exposed to flow instructions via `${env:KEY}`. Use `KEY1=VALUE1,KEY2=VALUE2`.
 - `suite-ids`: Comma-separated suite UUIDs to run after upload
 - `flow-ids`: Comma-separated flow UUIDs to run after upload
+- `browser`: Web only. Playwright engine to run on — `chromium` (default), `firefox`, or `edge`. Aliases accepted: `chrome` → `chromium`, `msedge` → `edge`. Ignored for mobile.
 
 Platform-specific required inputs:
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,9 @@ inputs:
   flow-ids:
     description: "Comma-separated flow UUIDs to run (e.g., 'uuid1,uuid2')"
     required: false
+  browser:
+    description: "[Web] Playwright engine to run on: chromium (default), firefox, or edge. Ignored for mobile platforms. Aliases accepted: chrome -> chromium, msedge -> edge."
+    required: false
 runs:
   using: "composite"
   steps:
@@ -74,3 +77,4 @@ runs:
         # Flow execution
         SUITE_IDS: ${{ inputs.suite-ids }}
         FLOW_IDS: ${{ inputs.flow-ids }}
+        BROWSER: ${{ inputs.browser }}

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   flow-ids:
     description: "Comma-separated flow UUIDs to run (e.g., 'uuid1,uuid2')"
     required: false
-  browser:
+  web-browser:
     description: "[Web] Playwright engine to run on: chromium (default), firefox, or edge. Ignored for mobile platforms. Aliases accepted: chrome -> chromium, msedge -> edge."
     required: false
 runs:
@@ -77,4 +77,4 @@ runs:
         # Flow execution
         SUITE_IDS: ${{ inputs.suite-ids }}
         FLOW_IDS: ${{ inputs.flow-ids }}
-        BROWSER: ${{ inputs.browser }}
+        WEB_BROWSER: ${{ inputs.web-browser }}

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
     description: "Comma-separated flow UUIDs to run (e.g., 'uuid1,uuid2')"
     required: false
   web-browser:
-    description: "[Web] Playwright engine to run on: chromium (default), firefox, or edge. Ignored for mobile platforms. Aliases accepted: chrome -> chromium, msedge -> edge."
+    description: "[Web] Playwright engine to run on: chrome (default, real Google Chrome with proprietary codecs / DRM), chromium (bundled engine, no codecs / DRM), firefox, or edge. Ignored for mobile platforms. Aliases accepted: msedge -> edge."
     required: false
 runs:
   using: "composite"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -520,20 +520,20 @@ fi
 
 # Build the run-flows payload based on platform.
 # `web_browser` is only meaningful for web; we omit it for mobile so the
-# backend doesn't reject it as an extra field. Empty/unset BROWSER is also
-# omitted, letting the backend default kick in (chromium).
+# backend doesn't reject it as an extra field. Empty/unset WEB_BROWSER is
+# also omitted, letting the backend default kick in (chromium).
 if [ "$PLATFORM" = "web" ]; then
   RUN_PAYLOAD=$(jq -n \
     --arg app_id "$APP_ID" \
     --arg environment "$ENVIRONMENT" \
     --arg variables "$VARIABLES" \
-    --arg browser "$BROWSER" \
+    --arg web_browser "$WEB_BROWSER" \
     --argjson flow_ids "$FLOW_IDS_JSON" \
     --argjson suite_ids "$SUITE_IDS_JSON" \
     '{app_id: $app_id, flow_ids: $flow_ids, suite_ids: $suite_ids}
      + (if $environment != "" then {environment: $environment} else {} end)
      + (if $variables != "" then {variables: $variables} else {} end)
-     + (if $browser != "" then {web_browser: $browser} else {} end)')
+     + (if $web_browser != "" then {web_browser: $web_browser} else {} end)')
 else
   RUN_PAYLOAD=$(jq -n \
     --arg bundle_id "$BUNDLE_ID" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -518,12 +518,21 @@ else
   SUITE_IDS_JSON="[]"
 fi
 
-# Validate WEB_BROWSER client-side. Without this, a typo like "firfox"
-# round-trips to the API and surfaces as a generic 4xx — failing locally
-# with a clear message is much faster to act on. Aliases (msedge, etc.)
-# are still accepted because the backend's normalize_web_browser resolves
-# them; we only reject inputs the backend wouldn't recognize.
-if [ -n "$WEB_BROWSER" ]; then
+# On mobile platforms, WEB_BROWSER is documented as "ignored" (action.yml +
+# README) — emit a one-line warning so a mis-wired matrix workflow surfaces
+# the drop, but DON'T validate or hard-fail. Validation only matters for
+# web; failing a mobile upload because of a typo in a field that mobile
+# ignores would break the documented contract.
+if [ -n "$WEB_BROWSER" ] && [ "$PLATFORM" != "web" ]; then
+  echo "⚠️  'web-browser' is web-only; ignoring '$WEB_BROWSER' for platform '$PLATFORM'."
+fi
+
+# Validate WEB_BROWSER client-side for WEB platform only. Without this, a
+# typo like "firfox" round-trips to the API and surfaces as a generic 4xx;
+# failing locally with a clear message is much faster to act on. Aliases
+# (msedge, etc.) are accepted because the backend's normalize_web_browser
+# resolves them; we only reject inputs the backend wouldn't recognize.
+if [ "$PLATFORM" = "web" ] && [ -n "$WEB_BROWSER" ]; then
   WEB_BROWSER_LOWER=$(echo "$WEB_BROWSER" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
   case "$WEB_BROWSER_LOWER" in
     chrome|chromium|firefox|edge|msedge)
@@ -537,16 +546,10 @@ if [ -n "$WEB_BROWSER" ]; then
   esac
 fi
 
-# Warn instead of silently dropping if user passed web-browser on mobile.
-# Catches mis-wired matrices where one job sets WEB_BROWSER for all platforms.
-if [ -n "$WEB_BROWSER" ] && [ "$PLATFORM" != "web" ]; then
-  echo "⚠️  'web-browser' is web-only; ignoring '$WEB_BROWSER' for platform '$PLATFORM'."
-fi
-
 # Build the run-flows payload based on platform.
 # `web_browser` is only meaningful for web; we omit it for mobile so the
 # backend doesn't reject it as an extra field. Empty/unset WEB_BROWSER is
-# also omitted, letting the backend default kick in (chromium).
+# also omitted, letting the backend default kick in (chrome).
 if [ "$PLATFORM" = "web" ]; then
   RUN_PAYLOAD=$(jq -n \
     --arg app_id "$APP_ID" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -520,18 +520,18 @@ fi
 
 # Validate WEB_BROWSER client-side. Without this, a typo like "firfox"
 # round-trips to the API and surfaces as a generic 4xx — failing locally
-# with a clear message is much faster to act on. Aliases (chrome, msedge,
-# etc.) are still accepted because the backend's normalize_web_browser
-# resolves them; we only reject inputs the backend wouldn't recognize.
+# with a clear message is much faster to act on. Aliases (msedge, etc.)
+# are still accepted because the backend's normalize_web_browser resolves
+# them; we only reject inputs the backend wouldn't recognize.
 if [ -n "$WEB_BROWSER" ]; then
   WEB_BROWSER_LOWER=$(echo "$WEB_BROWSER" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
   case "$WEB_BROWSER_LOWER" in
-    chromium|chrome|firefox|edge|msedge)
+    chrome|chromium|firefox|edge|msedge)
       ;;
     *)
       echo "❌ ERROR: Unsupported 'web-browser' value: '$WEB_BROWSER'"
-      echo "   Allowed: chromium (default), firefox, edge"
-      echo "   Aliases: chrome -> chromium, msedge -> edge"
+      echo "   Allowed: chrome (default), chromium, firefox, edge"
+      echo "   Aliases: msedge -> edge"
       exit 1
       ;;
   esac

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -518,6 +518,31 @@ else
   SUITE_IDS_JSON="[]"
 fi
 
+# Validate WEB_BROWSER client-side. Without this, a typo like "firfox"
+# round-trips to the API and surfaces as a generic 4xx — failing locally
+# with a clear message is much faster to act on. Aliases (chrome, msedge,
+# etc.) are still accepted because the backend's normalize_web_browser
+# resolves them; we only reject inputs the backend wouldn't recognize.
+if [ -n "$WEB_BROWSER" ]; then
+  WEB_BROWSER_LOWER=$(echo "$WEB_BROWSER" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+  case "$WEB_BROWSER_LOWER" in
+    chromium|chrome|firefox|edge|msedge)
+      ;;
+    *)
+      echo "❌ ERROR: Unsupported 'web-browser' value: '$WEB_BROWSER'"
+      echo "   Allowed: chromium (default), firefox, edge"
+      echo "   Aliases: chrome -> chromium, msedge -> edge"
+      exit 1
+      ;;
+  esac
+fi
+
+# Warn instead of silently dropping if user passed web-browser on mobile.
+# Catches mis-wired matrices where one job sets WEB_BROWSER for all platforms.
+if [ -n "$WEB_BROWSER" ] && [ "$PLATFORM" != "web" ]; then
+  echo "⚠️  'web-browser' is web-only; ignoring '$WEB_BROWSER' for platform '$PLATFORM'."
+fi
+
 # Build the run-flows payload based on platform.
 # `web_browser` is only meaningful for web; we omit it for mobile so the
 # backend doesn't reject it as an extra field. Empty/unset WEB_BROWSER is
@@ -550,7 +575,11 @@ fi
 echo "🔄 Triggering flows..."
 echo "   API Endpoint: $API_BASE_URL/api/v1/flows/run"
 echo "   Request Payload:"
-echo "$RUN_PAYLOAD" | jq '.'
+# Pipe through _redact_payload so the `variables` field (documented place
+# for user-supplied secrets like API tokens) doesn't leak into CI logs.
+# Every other payload echo in this script does this — the run-flows echo
+# is brand new; matching the existing convention.
+echo "$RUN_PAYLOAD" | _redact_payload | jq '.'
 echo ""
 
 RESPONSE=$(curl -s -X POST "$API_BASE_URL/api/v1/flows/run" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -518,17 +518,22 @@ else
   SUITE_IDS_JSON="[]"
 fi
 
-# Build the run-flows payload based on platform
+# Build the run-flows payload based on platform.
+# `web_browser` is only meaningful for web; we omit it for mobile so the
+# backend doesn't reject it as an extra field. Empty/unset BROWSER is also
+# omitted, letting the backend default kick in (chromium).
 if [ "$PLATFORM" = "web" ]; then
   RUN_PAYLOAD=$(jq -n \
     --arg app_id "$APP_ID" \
     --arg environment "$ENVIRONMENT" \
     --arg variables "$VARIABLES" \
+    --arg browser "$BROWSER" \
     --argjson flow_ids "$FLOW_IDS_JSON" \
     --argjson suite_ids "$SUITE_IDS_JSON" \
     '{app_id: $app_id, flow_ids: $flow_ids, suite_ids: $suite_ids}
      + (if $environment != "" then {environment: $environment} else {} end)
-     + (if $variables != "" then {variables: $variables} else {} end)')
+     + (if $variables != "" then {variables: $variables} else {} end)
+     + (if $browser != "" then {web_browser: $browser} else {} end)')
 else
   RUN_PAYLOAD=$(jq -n \
     --arg bundle_id "$BUNDLE_ID" \
@@ -544,6 +549,8 @@ fi
 
 echo "🔄 Triggering flows..."
 echo "   API Endpoint: $API_BASE_URL/api/v1/flows/run"
+echo "   Request Payload:"
+echo "$RUN_PAYLOAD" | jq '.'
 echo ""
 
 RESPONSE=$(curl -s -X POST "$API_BASE_URL/api/v1/flows/run" \

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -137,6 +137,38 @@ setup() {
     export WEB_BROWSER="firefox"
     export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
     run bash "$ENTRYPOINT"
+    assert_success
+    # Sanity check that we actually reached the run-flows step (otherwise an
+    # early-exit would make `refute_output` pass vacuously).
+    assert_output --partial "Running Flows"
+    # And the warning fires so users see the silent-drop avoided.
+    assert_output --partial "'web-browser' is web-only"
     # web_browser is only meaningful for web; mobile must not leak it.
     refute_output --partial '"web_browser"'
+}
+
+@test "validation rejects unknown web-browser values with a clear error" {
+    export PLATFORM="web"
+    export APP_ID="my-app"
+    export URL="https://example.com"
+    export FLOW_IDS="uuid-1"
+    export WEB_BROWSER="firfox"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Unsupported 'web-browser' value"
+    # Did not reach the API call.
+    refute_output --partial "Triggering flows"
+}
+
+@test "validation accepts web-browser aliases (chrome, msedge)" {
+    export PLATFORM="web"
+    export APP_ID="my-app"
+    export URL="https://example.com"
+    export FLOW_IDS="uuid-1"
+    export WEB_BROWSER="msedge"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    # Forwarded as-is; the backend's normalize_web_browser maps to canonical.
+    assert_output --partial '"web_browser": "msedge"'
 }

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -105,36 +105,36 @@ setup() {
 
 # --- Browser engine selection (web only) ---
 
-@test "web payload includes web_browser when BROWSER is set" {
+@test "web payload includes web_browser when WEB_BROWSER is set" {
     export PLATFORM="web"
     export APP_ID="my-app"
     export URL="https://example.com"
     export FLOW_IDS="uuid-1"
-    export BROWSER="firefox"
+    export WEB_BROWSER="firefox"
     export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
     run bash "$ENTRYPOINT"
     assert_success
     assert_output --partial '"web_browser": "firefox"'
 }
 
-@test "web payload omits web_browser when BROWSER is empty (backend default)" {
+@test "web payload omits web_browser when WEB_BROWSER is empty (backend default)" {
     export PLATFORM="web"
     export APP_ID="my-app"
     export URL="https://example.com"
     export FLOW_IDS="uuid-1"
-    export BROWSER=""
+    export WEB_BROWSER=""
     export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
     run bash "$ENTRYPOINT"
     assert_success
     refute_output --partial '"web_browser"'
 }
 
-@test "mobile payload never includes web_browser even when BROWSER is set" {
+@test "mobile payload never includes web_browser even when WEB_BROWSER is set" {
     export PLATFORM="android"
     export BUNDLE_ID="com.example.app"
     export BUILD_PATH="$PROJECT_ROOT/tests/fixtures/dummy.apk"
     export FLOW_IDS="uuid-1"
-    export BROWSER="firefox"
+    export WEB_BROWSER="firefox"
     export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
     run bash "$ENTRYPOINT"
     # web_browser is only meaningful for web; mobile must not leak it.

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -160,6 +160,31 @@ setup() {
     refute_output --partial "Triggering flows"
 }
 
+@test "invalid web-browser on mobile warns but doesn't hard-fail (cursor[bot] regression)" {
+    # Regression for cursor[bot] Medium finding: validation must NOT run on
+    # mobile platforms — action.yml + README document web-browser as
+    # "ignored for mobile", so a typo there should warn-and-continue, not
+    # hard-fail the upload. Previously the validation block ran
+    # unconditionally and a misconfigured matrix workflow with
+    # `web-browser: firfox` + `platform: android` would fail the upload.
+    export PLATFORM="android"
+    export BUNDLE_ID="com.example.app"
+    export BUILD_PATH="$PROJECT_ROOT/tests/fixtures/dummy.apk"
+    export FLOW_IDS="uuid-1"
+    export WEB_BROWSER="firfox"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    # The warning fires.
+    assert_output --partial "'web-browser' is web-only"
+    # And we proceed to the upload + run-flows step (mobile contract).
+    assert_output --partial "Running Flows"
+    # And we did NOT hard-fail with the validation error.
+    refute_output --partial "Unsupported 'web-browser' value"
+    # And the mobile payload still doesn't leak web_browser into the API call.
+    refute_output --partial '"web_browser"'
+}
+
 @test "validation accepts web-browser aliases (chrome, msedge)" {
     export PLATFORM="web"
     export APP_ID="my-app"

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -102,3 +102,41 @@ setup() {
     assert_success
     assert_output --partial '"app_id"'
 }
+
+# --- Browser engine selection (web only) ---
+
+@test "web payload includes web_browser when BROWSER is set" {
+    export PLATFORM="web"
+    export APP_ID="my-app"
+    export URL="https://example.com"
+    export FLOW_IDS="uuid-1"
+    export BROWSER="firefox"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial '"web_browser": "firefox"'
+}
+
+@test "web payload omits web_browser when BROWSER is empty (backend default)" {
+    export PLATFORM="web"
+    export APP_ID="my-app"
+    export URL="https://example.com"
+    export FLOW_IDS="uuid-1"
+    export BROWSER=""
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    refute_output --partial '"web_browser"'
+}
+
+@test "mobile payload never includes web_browser even when BROWSER is set" {
+    export PLATFORM="android"
+    export BUNDLE_ID="com.example.app"
+    export BUILD_PATH="$PROJECT_ROOT/tests/fixtures/dummy.apk"
+    export FLOW_IDS="uuid-1"
+    export BROWSER="firefox"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
+    run bash "$ENTRYPOINT"
+    # web_browser is only meaningful for web; mobile must not leak it.
+    refute_output --partial '"web_browser"'
+}

--- a/tests/test_helper/common-setup.bash
+++ b/tests/test_helper/common-setup.bash
@@ -24,6 +24,13 @@ _common_setup() {
     export VARIABLES=""
     export SUITE_IDS=""
     export FLOW_IDS=""
+    # Initialize WEB_BROWSER explicitly so a stray value in the outer shell
+    # (developer's local env, CI runner inheriting from a parent process)
+    # doesn't leak into tests that don't override it. Validation in
+    # entrypoint.sh exits 1 on unrecognized values for web platforms, so an
+    # uninitialized WEB_BROWSER like "develop" or "main" could otherwise
+    # cause spurious failures across most tests.
+    export WEB_BROWSER=""
 
     # GitHub env vars (mocked)
     export GITHUB_EVENT_PATH="$PROJECT_ROOT/tests/fixtures/github_event_push.json"


### PR DESCRIPTION
## Summary

Add a `browser` action input so web flows triggered via the action can pick the Playwright engine (Chromium / Firefox / Edge) — same surface the API, MCP, and dashboard already expose.

- New `browser` input on `action.yml` with description + alias guidance
- `entrypoint.sh` threads it into the `/api/v1/flows/run` payload as `web_browser` for web platform; ignored on mobile
- Empty / unset → omitted from payload, backend defaults to chromium (no change for existing users)
- Aliases (`chrome` → `chromium`, `msedge` → `edge`) handled by the backend's existing `normalize_web_browser` validator
- Echo the run-flows payload before posting so it's visible in CI logs (useful for debugging)
- README updated
- Tests added (3) covering: set on web → present, empty on web → omitted, set on mobile → never leaked. All 68 bats tests pass.

Pairs with backend [#795](https://github.com/Autosana/AutosanaBackend/pull/795) and dashboard [#716](https://github.com/Autosana/AutosanaDashboard/pull/716).

## Test plan

- [x] `bats tests/` — 68/68 pass
- [x] Manual review of action.yml + entrypoint.sh + README
- [ ] Smoke: dispatch a web flow via this branch's action with `browser: firefox`, confirm payload reaches API and run lands on Firefox

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional web-browser parameter to select the Playwright engine for Web runs; ignored for mobile.

* **Documentation**
  * README updated with default, supported engines, alias mapping, and mobile behavior.

* **Behavior**
  * Normalizes/validates web-browser for Web runs, warns if set on non-Web platforms, forwards selection for Web payloads, and logs outgoing request payloads with sensitive fields redacted.

* **Tests**
  * Added tests covering selection, aliases, validation, platform-specific behavior, and test setup resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->