### PR TITLE
fix: exit non-zero when flows are terminated

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -740,11 +740,18 @@ echo "   Flows:   $PASSED/$TOTAL passed"
 [ "$SKIPPED" != "0" ] && echo "   Skipped: $SKIPPED"
 echo ""
 
-UNSUCCESSFUL=$((FAILED + ERROR_COUNT))
+# Anything that isn't `passed` or `skipped` is a failure. Computing this as
+# (TOTAL - PASSED - SKIPPED) instead of summing the bad buckets means we
+# fail closed if the backend ever introduces a new non-passing status
+# (e.g. `cancelled`, `timed_out`) — better to surface a CI failure than to
+# silently report green. This also fixes a regression where a run with
+# only TERMINATED flows (worker crash, infra issue, manual kill) exited 0
+# and printed "All flows passed!" — see customer report.
+UNSUCCESSFUL=$((TOTAL - PASSED - SKIPPED))
 if [ "$UNSUCCESSFUL" -gt 0 ]; then
-  echo "❌ $UNSUCCESSFUL flow(s) did not pass."
+  echo "❌ $UNSUCCESSFUL flow(s) did not pass (failed: $FAILED, error: $ERROR_COUNT, terminated: $TERMINATED)."
   exit 1
 else
-  echo "✅ All flows passed!"
+  echo "✅ All flows passed ($PASSED/$TOTAL)."
   exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -757,8 +757,23 @@ ACCOUNTED_FOR=$((PASSED + SKIPPED))
 if [ "$TOTAL" -gt 0 ] && [ "$ACCOUNTED_FOR" -eq "$TOTAL" ]; then
   echo "✅ All flows passed ($PASSED/$TOTAL)."
   exit 0
+elif [ "$TOTAL" -le 0 ]; then
+  # No flows accounted for at all — empty batch / zeroed summary. Don't
+  # try to invent a count; just say so plainly.
+  echo "❌ No flows ran (TOTAL=$TOTAL). Refusing to report success."
+  exit 1
 else
+  # TOTAL > 0 but ACCOUNTED_FOR != TOTAL. In the normal case
+  # (ACCOUNTED_FOR < TOTAL) this is the count of non-passed, non-skipped
+  # flows. In the inconsistent-counters case (ACCOUNTED_FOR > TOTAL) the
+  # subtraction would be negative, which is meaningless to print — fall
+  # back to a generic message rather than emit "❌ -1 flow(s) did not pass".
   UNACCOUNTED=$((TOTAL - ACCOUNTED_FOR))
-  echo "❌ $UNACCOUNTED flow(s) did not pass (failed: $FAILED, error: $ERROR_COUNT, terminated: $TERMINATED)."
+  if [ "$UNACCOUNTED" -gt 0 ]; then
+    echo "❌ $UNACCOUNTED flow(s) did not pass (failed: $FAILED, error: $ERROR_COUNT, terminated: $TERMINATED)."
+  else
+    echo "❌ Inconsistent run summary: passed=$PASSED, skipped=$SKIPPED, total=$TOTAL (failed: $FAILED, error: $ERROR_COUNT, terminated: $TERMINATED)."
+  fi
   exit 1
 fi
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -740,18 +740,25 @@ echo "   Flows:   $PASSED/$TOTAL passed"
 [ "$SKIPPED" != "0" ] && echo "   Skipped: $SKIPPED"
 echo ""
 
-# Anything that isn't `passed` or `skipped` is a failure. Computing this as
-# (TOTAL - PASSED - SKIPPED) instead of summing the bad buckets means we
-# fail closed if the backend ever introduces a new non-passing status
-# (e.g. `cancelled`, `timed_out`) — better to surface a CI failure than to
-# silently report green. This also fixes a regression where a run with
-# only TERMINATED flows (worker crash, infra issue, manual kill) exited 0
-# and printed "All flows passed!" — see customer report.
-UNSUCCESSFUL=$((TOTAL - PASSED - SKIPPED))
-if [ "$UNSUCCESSFUL" -gt 0 ]; then
-  echo "❌ $UNSUCCESSFUL flow(s) did not pass (failed: $FAILED, error: $ERROR_COUNT, terminated: $TERMINATED)."
-  exit 1
-else
+# Success requires (a) we actually ran something, and (b) every flow either
+# passed or was intentionally skipped (e.g. platform filter). Phrasing it as
+# an explicit positive condition — rather than `(TOTAL - PASSED - SKIPPED) > 0`
+# — fails closed in two edge cases:
+#   1. TOTAL == 0  (empty batch / API glitch returning zeros): subtracting
+#      would give 0 and silently exit 0 with "All flows passed (0/0)".
+#   2. PASSED + SKIPPED > TOTAL  (inconsistent counters, jq `// 0` fallback
+#      hitting siblings unevenly): subtracting would go negative and
+#      `-gt 0` would be false → silent exit 0, reintroducing the exact
+#      fail-open class this script is trying to close.
+# This also fixes the original customer report: a run with only TERMINATED
+# flows (worker crash, infra issue, manual kill) exited 0 and printed
+# "All flows passed!" because the previous logic only summed FAILED + ERROR.
+ACCOUNTED_FOR=$((PASSED + SKIPPED))
+if [ "$TOTAL" -gt 0 ] && [ "$ACCOUNTED_FOR" -eq "$TOTAL" ]; then
   echo "✅ All flows passed ($PASSED/$TOTAL)."
   exit 0
+else
+  UNACCOUNTED=$((TOTAL - ACCOUNTED_FOR))
+  echo "❌ $UNACCOUNTED flow(s) did not pass (failed: $FAILED, error: $ERROR_COUNT, terminated: $TERMINATED)."
+  exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -755,7 +755,16 @@ echo ""
 # "All flows passed!" because the previous logic only summed FAILED + ERROR.
 ACCOUNTED_FOR=$((PASSED + SKIPPED))
 if [ "$TOTAL" -gt 0 ] && [ "$ACCOUNTED_FOR" -eq "$TOTAL" ]; then
-  echo "✅ All flows passed ($PASSED/$TOTAL)."
+  if [ "$PASSED" -gt 0 ]; then
+    echo "✅ All flows passed ($PASSED/$TOTAL)."
+  else
+    # Every flow was intentionally skipped (e.g. matrix slot where the
+    # platform filter excluded everything). This is still a green build —
+    # users rely on it for `platform: ios` jobs that skip android-only
+    # flows and vice versa — but the previous "All flows passed (0/N)"
+    # message was self-contradictory. Be explicit instead.
+    echo "✅ No applicable flows ran (0 passed, $SKIPPED skipped)."
+  fi
   exit 0
 elif [ "$TOTAL" -le 0 ]; then
   # No flows accounted for at all — empty batch / zeroed summary. Don't

--- a/tests/fixtures/poll_all_skipped.json
+++ b/tests/fixtures/poll_all_skipped.json
@@ -1,0 +1,34 @@
+{
+  "is_complete": true,
+  "run_groups": [
+    {
+      "name": "iOS-only Suite",
+      "runs": [
+        {
+          "id": "run-1",
+          "name": "iOS Login Flow",
+          "status": "skipped",
+          "url": "https://app.autosana.ai/runs/run-1",
+          "summary": ""
+        },
+        {
+          "id": "run-2",
+          "name": "iOS Checkout Flow",
+          "status": "skipped",
+          "url": "https://app.autosana.ai/runs/run-2",
+          "summary": ""
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_groups": 1,
+    "passed_groups": 0,
+    "total_flows": 2,
+    "passed_flows": 0,
+    "failed_flows": 0,
+    "error_flows": 0,
+    "terminated_flows": 0,
+    "skipped_flows": 2
+  }
+}

--- a/tests/fixtures/poll_all_terminated.json
+++ b/tests/fixtures/poll_all_terminated.json
@@ -1,0 +1,34 @@
+{
+  "is_complete": true,
+  "run_groups": [
+    {
+      "name": "Smoke Tests",
+      "runs": [
+        {
+          "id": "run-1",
+          "name": "Login Flow",
+          "status": "terminated",
+          "url": "https://app.autosana.ai/runs/run-1",
+          "summary": ""
+        },
+        {
+          "id": "run-2",
+          "name": "Checkout Flow",
+          "status": "terminated",
+          "url": "https://app.autosana.ai/runs/run-2",
+          "summary": ""
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_groups": 1,
+    "passed_groups": 0,
+    "total_flows": 2,
+    "passed_flows": 0,
+    "failed_flows": 0,
+    "error_flows": 0,
+    "terminated_flows": 2,
+    "skipped_flows": 0
+  }
+}

--- a/tests/fixtures/poll_empty_batch.json
+++ b/tests/fixtures/poll_empty_batch.json
@@ -1,0 +1,14 @@
+{
+  "is_complete": true,
+  "run_groups": [],
+  "summary": {
+    "total_groups": 0,
+    "passed_groups": 0,
+    "total_flows": 0,
+    "passed_flows": 0,
+    "failed_flows": 0,
+    "error_flows": 0,
+    "terminated_flows": 0,
+    "skipped_flows": 0
+  }
+}

--- a/tests/fixtures/poll_inconsistent_counters.json
+++ b/tests/fixtures/poll_inconsistent_counters.json
@@ -1,0 +1,27 @@
+{
+  "is_complete": true,
+  "run_groups": [
+    {
+      "name": "Smoke Tests",
+      "runs": [
+        {
+          "id": "run-1",
+          "name": "Login Flow",
+          "status": "passed",
+          "url": "https://app.autosana.ai/runs/run-1",
+          "summary": ""
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_groups": 1,
+    "passed_groups": 1,
+    "total_flows": 2,
+    "passed_flows": 3,
+    "failed_flows": 0,
+    "error_flows": 0,
+    "terminated_flows": 0,
+    "skipped_flows": 0
+  }
+}

--- a/tests/fixtures/poll_mixed_results.json
+++ b/tests/fixtures/poll_mixed_results.json
@@ -1,0 +1,55 @@
+{
+  "is_complete": true,
+  "run_groups": [
+    {
+      "name": "Smoke Tests",
+      "runs": [
+        {
+          "id": "run-1",
+          "name": "Login Flow",
+          "status": "passed",
+          "url": "https://app.autosana.ai/runs/run-1",
+          "summary": ""
+        },
+        {
+          "id": "run-2",
+          "name": "Checkout Flow",
+          "status": "failed",
+          "url": "https://app.autosana.ai/runs/run-2",
+          "summary": "Button not found"
+        },
+        {
+          "id": "run-3",
+          "name": "Search Flow",
+          "status": "error",
+          "url": "https://app.autosana.ai/runs/run-3",
+          "summary": "Network timeout"
+        },
+        {
+          "id": "run-4",
+          "name": "Profile Flow",
+          "status": "terminated",
+          "url": "https://app.autosana.ai/runs/run-4",
+          "summary": ""
+        },
+        {
+          "id": "run-5",
+          "name": "iOS-only Flow",
+          "status": "skipped",
+          "url": "https://app.autosana.ai/runs/run-5",
+          "summary": ""
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_groups": 1,
+    "passed_groups": 0,
+    "total_flows": 5,
+    "passed_flows": 1,
+    "failed_flows": 1,
+    "error_flows": 1,
+    "terminated_flows": 1,
+    "skipped_flows": 1
+  }
+}

--- a/tests/fixtures/poll_passed_with_skipped.json
+++ b/tests/fixtures/poll_passed_with_skipped.json
@@ -1,0 +1,34 @@
+{
+  "is_complete": true,
+  "run_groups": [
+    {
+      "name": "Smoke Tests",
+      "runs": [
+        {
+          "id": "run-1",
+          "name": "Login Flow",
+          "status": "passed",
+          "url": "https://app.autosana.ai/runs/run-1",
+          "summary": ""
+        },
+        {
+          "id": "run-2",
+          "name": "iOS-only Flow",
+          "status": "skipped",
+          "url": "https://app.autosana.ai/runs/run-2",
+          "summary": ""
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_groups": 1,
+    "passed_groups": 1,
+    "total_flows": 2,
+    "passed_flows": 1,
+    "failed_flows": 0,
+    "error_flows": 0,
+    "terminated_flows": 0,
+    "skipped_flows": 1
+  }
+}

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -132,6 +132,20 @@ setup() {
     assert_output --partial "Skipped: 1"
 }
 
+# A matrix CI job (e.g. `platform: ios`) can legitimately skip every flow
+# when the suite is android-only and vice versa. That should stay a green
+# build — but the previous message read "✅ All flows passed (0/2)." which
+# is self-contradictory (Cursor Bugbot Medium finding on 4c156b4). Assert
+# we still exit 0 and that the message is no longer a contradiction.
+@test "all flows skipped exits 0 with non-contradictory message" {
+    export FLOW_IDS="uuid-1"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_skipped.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "No applicable flows ran (0 passed, 2 skipped)"
+    refute_output --partial "All flows passed (0/"
+}
+
 # Defense in depth: if total_flows is 0 (empty batch / API glitch), the
 # action must NOT print "All flows passed (0/0)" and exit 0. This was a
 # fail-open class flagged in PR review.

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -92,6 +92,32 @@ setup() {
     assert_output --partial "Failed:  1"
 }
 
+# Regression: a customer reported a run with 0/72 flows passed and 37
+# terminated still exited 0 with "✅ All flows passed!". Terminated flows
+# (worker crash, infra issue, manual kill) are not passes — they must
+# fail the action so CI surfaces the breakage instead of merging green.
+@test "all flows terminated exits 1 (regression)" {
+    export FLOW_IDS="uuid-1"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_terminated.json"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Terminated: 2"
+    assert_output --partial "did not pass"
+    assert_output --partial "terminated: 2"
+    refute_output --partial "All flows passed"
+}
+
+# Skipped flows are intentional (e.g. platform filter), so they shouldn't
+# fail the action. A run where every non-skipped flow passed should exit 0.
+@test "passed plus skipped flows exits 0" {
+    export FLOW_IDS="uuid-1"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_passed_with_skipped.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "Skipped: 1"
+    assert_output --partial "All flows passed (1/2)"
+}
+
 @test "web platform flow payload uses app_id not bundle_id" {
     export PLATFORM="web"
     export APP_ID="my-app"

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -118,6 +118,43 @@ setup() {
     assert_output --partial "All flows passed (1/2)"
 }
 
+# A real-world failing run usually has multiple buckets populated. Lock in
+# that the failure-message string surfaces all counts (PR-bot ask).
+@test "mixed results (failed+error+terminated+skipped) exits 1 with itemized counts" {
+    export FLOW_IDS="uuid-1"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_mixed_results.json"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "did not pass (failed: 1, error: 1, terminated: 1)"
+    assert_output --partial "Failed:  1"
+    assert_output --partial "Error:   1"
+    assert_output --partial "Terminated: 1"
+    assert_output --partial "Skipped: 1"
+}
+
+# Defense in depth: if total_flows is 0 (empty batch / API glitch), the
+# action must NOT print "All flows passed (0/0)" and exit 0. This was a
+# fail-open class flagged in PR review.
+@test "empty batch (TOTAL=0) fails closed instead of claiming success" {
+    export FLOW_IDS="uuid-1"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_empty_batch.json"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    refute_output --partial "All flows passed"
+}
+
+# Defense in depth: if the backend returns inconsistent counters such that
+# PASSED + SKIPPED > TOTAL (e.g. mismatched `// 0` fallbacks), a naive
+# subtraction would go negative and silently exit 0. Make sure we fail
+# closed instead — PR-bot regression.
+@test "inconsistent counters (PASSED+SKIPPED > TOTAL) fails closed" {
+    export FLOW_IDS="uuid-1"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_inconsistent_counters.json"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    refute_output --partial "All flows passed"
+}
+
 @test "web platform flow payload uses app_id not bundle_id" {
     export PLATFORM="web"
     export APP_ID="my-app"

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -141,18 +141,22 @@ setup() {
     run bash "$ENTRYPOINT"
     assert_failure
     refute_output --partial "All flows passed"
+    assert_output --partial "No flows ran"
 }
 
 # Defense in depth: if the backend returns inconsistent counters such that
 # PASSED + SKIPPED > TOTAL (e.g. mismatched `// 0` fallbacks), a naive
 # subtraction would go negative and silently exit 0. Make sure we fail
-# closed instead — PR-bot regression.
-@test "inconsistent counters (PASSED+SKIPPED > TOTAL) fails closed" {
+# closed AND emit a sensible message instead of "❌ -1 flow(s) did not
+# pass" — PR-bot regression (Cursor Bugbot Low finding on cf50cf0).
+@test "inconsistent counters (PASSED+SKIPPED > TOTAL) fails closed with a sensible message" {
     export FLOW_IDS="uuid-1"
     export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_inconsistent_counters.json"
     run bash "$ENTRYPOINT"
     assert_failure
     refute_output --partial "All flows passed"
+    assert_output --partial "Inconsistent run summary"
+    refute_output --regexp '❌ -[0-9]+ flow'
 }
 
 @test "web platform flow payload uses app_id not bundle_id" {


### PR DESCRIPTION
Fixes AUT-1318

## Summary

A customer reported that a run with `0/72 flows passed` and `37 terminated` still exited `0` and printed `✅ All flows passed!`. The action's exit-code logic only summed `failed + error`, so terminated flows (worker crash, infra issue, manual kill) were silently treated as passes and could let broken builds merge green.

## What changed

- `entrypoint.sh`: gate exit code on `(TOTAL - PASSED - SKIPPED) > 0` instead of summing the bad buckets. This fixes terminated flows and also fails closed if the backend ever introduces a new non-passing status (`cancelled`, `timed_out`, etc.) — better to surface a CI failure than silently report green.
- Skipped flows (intentional, e.g. platform filter) still exit `0`.
- Success message now prints `All flows passed (N/M).` so it can't claim victory when `PASSED == 0`.
- Failure message now breaks down what was unsuccessful: `did not pass (failed: X, error: Y, terminated: Z)`.

## Tests

- New fixture `poll_all_terminated.json` + bats case `all flows terminated exits 1 (regression)` locks in the customer-reported scenario.
- New fixture `poll_passed_with_skipped.json` + bats case `passed plus skipped flows exits 0` makes sure intentional skips don't fail builds.
- Full suite: 73/73 passing locally (`make test`).

## Test plan

- [x] `make test` passes
- [ ] Manually trigger a run that produces only terminated flows and confirm the action exits 1
- [ ] Manually trigger a run with skipped + passed flows and confirm the action exits 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced failure detection to treat any non-passing status (e.g., terminated) as unsuccessful.
  * Improved result summaries to include status breakdown and passed/total ratio reporting.

* **Tests**
  * Added validation for terminated and skipped flow execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->