### PR TITLE
Add configurable timeout for flow polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Shared optional inputs:
 - `suite-ids`: Comma-separated suite UUIDs to run after upload
 - `flow-ids`: Comma-separated flow UUIDs to run after upload
 - `web-browser`: Web only. Playwright engine to run on — `chrome` (default, real Google Chrome with proprietary codecs and DRM), `chromium` (bundled Chromium engine, no codecs / DRM), `firefox`, or `edge`. Aliases accepted: `msedge` → `edge`. Ignored for mobile.
+- `poll-timeout-seconds`: Maximum seconds to wait for triggered flows before failing the action. Defaults to `1800`.
 
 Platform-specific required inputs:
 
@@ -54,4 +55,5 @@ Platform-specific required inputs:
     environment: staging
     variables: "TEST_ACCOUNT=qa-smoke,CHECKOUT_VARIANT=control"
     flow-ids: "uuid-1,uuid-2"
+    poll-timeout-seconds: "1200"
 ```

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
   web-browser:
     description: "[Web] Playwright engine to run on: chrome (default, real Google Chrome with proprietary codecs / DRM), chromium (bundled engine, no codecs / DRM), firefox, or edge. Ignored for mobile platforms. Aliases accepted: msedge -> edge."
     required: false
+  poll-timeout-seconds:
+    description: "Maximum seconds to wait for triggered flows before failing the action. Set to 0 to fail immediately if the first status poll is incomplete."
+    required: false
+    default: "1800"
 runs:
   using: "composite"
   steps:
@@ -78,3 +82,4 @@ runs:
         SUITE_IDS: ${{ inputs.suite-ids }}
         FLOW_IDS: ${{ inputs.flow-ids }}
         WEB_BROWSER: ${{ inputs.web-browser }}
+        POLL_TIMEOUT_SECONDS: ${{ inputs.poll-timeout-seconds }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -637,6 +637,15 @@ _poll_elapsed_seconds() {
   echo "$(($(date +%s) - POLL_STARTED_AT))"
 }
 
+_poll_remaining_seconds() {
+  REMAINING=$((POLL_TIMEOUT_SECONDS - $(_poll_elapsed_seconds)))
+  if [ "$REMAINING" -gt 0 ]; then
+    echo "$REMAINING"
+  else
+    echo 0
+  fi
+}
+
 _poll_timed_out() {
   [ "$(_poll_elapsed_seconds)" -ge "$POLL_TIMEOUT_SECONDS" ]
 }
@@ -648,13 +657,32 @@ _fail_poll_timeout() {
   exit 1
 }
 
+_sleep_before_next_poll() {
+  REMAINING=$(_poll_remaining_seconds)
+  if [ "$REMAINING" -le 0 ]; then
+    _fail_poll_timeout
+  fi
+
+  if [ "$REMAINING" -lt "$POLL_INTERVAL" ]; then
+    sleep "$REMAINING"
+  else
+    sleep "$POLL_INTERVAL"
+  fi
+}
+
 echo "   Poll timeout: ${POLL_TIMEOUT_SECONDS}s"
 
 PRINTED_IDS_FILE=$(mktemp)
 trap "rm -f $PRINTED_IDS_FILE" EXIT
 
 # Initial poll to show all flow links upfront
-sleep 2
+INITIAL_SLEEP=$(_poll_remaining_seconds)
+if [ "$INITIAL_SLEEP" -gt 2 ]; then
+  INITIAL_SLEEP=2
+fi
+if [ "$INITIAL_SLEEP" -gt 0 ]; then
+  sleep "$INITIAL_SLEEP"
+fi
 INIT_RESPONSE=$(curl -s -X GET "$API_BASE_URL/api/v1/runs/status?batch_id=$BATCH_ID" \
   --connect-timeout 30 \
   --max-time 30 \
@@ -676,6 +704,17 @@ if echo "$INIT_RESPONSE" | jq empty 2>/dev/null; then
   echo ""
 fi
 
+if echo "$INIT_RESPONSE" | jq empty 2>/dev/null; then
+  INIT_COMPLETE=$(echo "$INIT_RESPONSE" | jq -r '.is_complete')
+  if [ "$INIT_COMPLETE" != "true" ] && _poll_timed_out; then
+    STATUS_RESPONSE="$INIT_RESPONSE"
+    _fail_poll_timeout
+  fi
+elif _poll_timed_out; then
+  STATUS_RESPONSE="$INIT_RESPONSE"
+  _fail_poll_timeout
+fi
+
 echo "⏳ Waiting for results..."
 echo ""
 
@@ -690,7 +729,7 @@ while true; do
     if _poll_timed_out; then
       _fail_poll_timeout
     fi
-    sleep "$POLL_INTERVAL"
+    _sleep_before_next_poll
     continue
   fi
 
@@ -747,7 +786,7 @@ while true; do
     _fail_poll_timeout
   fi
 
-  sleep "$POLL_INTERVAL"
+  _sleep_before_next_poll
 done
 
 # Final summary

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -505,6 +505,15 @@ echo "🔬 Running Flows"
 echo "🔬 ========================================"
 echo ""
 
+POLL_INTERVAL=15
+POLL_TIMEOUT_SECONDS="${POLL_TIMEOUT_SECONDS:-1800}"
+
+if ! echo "$POLL_TIMEOUT_SECONDS" | grep -qE '^[0-9]+$'; then
+  echo "❌ ERROR: Invalid poll-timeout-seconds value: '$POLL_TIMEOUT_SECONDS'"
+  echo "   Must be a non-negative integer number of seconds."
+  exit 1
+fi
+
 # Convert comma-separated IDs to JSON arrays (strip whitespace)
 if [ -n "$FLOW_IDS" ]; then
   FLOW_IDS_JSON=$(echo "$FLOW_IDS" | tr -d ' ' | tr ',' '\n' | sed '/^$/d' | jq -R . | jq -s .)
@@ -622,7 +631,25 @@ echo "   Batch ID: $BATCH_ID"
 echo ""
 
 # Polling configuration
-POLL_INTERVAL=15
+POLL_STARTED_AT=$(date +%s)
+
+_poll_elapsed_seconds() {
+  echo "$(($(date +%s) - POLL_STARTED_AT))"
+}
+
+_poll_timed_out() {
+  [ "$(_poll_elapsed_seconds)" -ge "$POLL_TIMEOUT_SECONDS" ]
+}
+
+_fail_poll_timeout() {
+  echo "❌ ERROR: Timed out waiting for Autosana flows after $(_poll_elapsed_seconds)s (limit: ${POLL_TIMEOUT_SECONDS}s)."
+  echo "   Batch ID: $BATCH_ID"
+  echo "   Last status response: ${STATUS_RESPONSE:-<none>}"
+  exit 1
+}
+
+echo "   Poll timeout: ${POLL_TIMEOUT_SECONDS}s"
+
 PRINTED_IDS_FILE=$(mktemp)
 trap "rm -f $PRINTED_IDS_FILE" EXIT
 
@@ -660,6 +687,9 @@ while true; do
 
   if ! echo "$STATUS_RESPONSE" | jq empty 2>/dev/null; then
     echo "   ⚠ Warning: Invalid response from status API, retrying..."
+    if _poll_timed_out; then
+      _fail_poll_timeout
+    fi
     sleep "$POLL_INTERVAL"
     continue
   fi
@@ -711,6 +741,10 @@ while true; do
   IS_COMPLETE=$(echo "$STATUS_RESPONSE" | jq -r '.is_complete')
   if [ "$IS_COMPLETE" = "true" ]; then
     break
+  fi
+
+  if _poll_timed_out; then
+    _fail_poll_timeout
   fi
 
   sleep "$POLL_INTERVAL"
@@ -785,4 +819,3 @@ else
   fi
   exit 1
 fi
-

--- a/tests/fixtures/poll_in_progress.json
+++ b/tests/fixtures/poll_in_progress.json
@@ -1,0 +1,26 @@
+{
+  "is_complete": false,
+  "run_groups": [
+    {
+      "name": "Smoke",
+      "runs": [
+        {
+          "id": "run-1",
+          "name": "Login smoke",
+          "status": "running",
+          "url": "https://autosana.ai/runs/run-1"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total_groups": 1,
+    "passed_groups": 0,
+    "total_flows": 1,
+    "passed_flows": 0,
+    "failed_flows": 0,
+    "error_flows": 0,
+    "terminated_flows": 0,
+    "skipped_flows": 0
+  }
+}

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -278,3 +278,22 @@ setup() {
     # Forwarded as-is; the backend's normalize_web_browser maps to canonical.
     assert_output --partial '"web_browser": "msedge"'
 }
+
+@test "polling times out instead of hanging forever" {
+    export FLOW_IDS="uuid-1"
+    export POLL_TIMEOUT_SECONDS="0"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_in_progress.json"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Timed out waiting for Autosana flows"
+    assert_output --partial "Batch ID: batch-001"
+}
+
+@test "poll timeout rejects non-numeric values" {
+    export FLOW_IDS="uuid-1"
+    export POLL_TIMEOUT_SECONDS="soon"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Invalid poll-timeout-seconds value"
+    refute_output --partial "Waiting for results"
+}

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -289,6 +289,19 @@ setup() {
     assert_output --partial "Batch ID: batch-001"
 }
 
+@test "zero poll timeout checks status before any startup sleep" {
+    export FLOW_IDS="uuid-1"
+    export POLL_TIMEOUT_SECONDS="0"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_in_progress.json"
+    export MOCK_SLEEP_LOG="$BATS_TEST_TMPDIR/sleeps.log"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Timed out waiting for Autosana flows"
+    if [ -f "$MOCK_SLEEP_LOG" ]; then
+        refute grep -Fx "2" "$MOCK_SLEEP_LOG"
+    fi
+}
+
 @test "poll timeout rejects non-numeric values" {
     export FLOW_IDS="uuid-1"
     export POLL_TIMEOUT_SECONDS="soon"

--- a/tests/mocks/sleep
+++ b/tests/mocks/sleep
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 # no-op: skip all sleeps during tests
+if [ -n "$MOCK_SLEEP_LOG" ]; then
+    echo "$*" >> "$MOCK_SLEEP_LOG"
+fi
 exit 0


### PR DESCRIPTION
## Summary
- add a poll-timeout-seconds action input so triggered flows cannot hang a CI job forever
- fail with the batch id and last status response when the status endpoint stays incomplete or invalid past the limit
- document the input and cover timeout/non-numeric cases with Bats fixtures

## Why
After the run-flows API call, the action polls the run-status endpoint until is_complete=true. If a run is stuck, the status API keeps returning incomplete data, or the API keeps returning invalid JSON, the current loop retries forever until GitHub Actions kills the job. This makes failures slower and less diagnosable.

## Tests
- npx --yes bats@latest tests/flow_execution.bats
- npx --yes bats@latest tests/*.bats
- bash -n entrypoint.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `poll-timeout-seconds` input to control maximum wait time for triggered flows (default: 1800 seconds)

* **Bug Fixes**
  * Improved timeout validation with clearer error messages when timeout is exceeded
  * Enhanced flow run success criteria validation

* **Tests**
  * Added tests for timeout configuration and polling behavior validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Autosana/autosana-ci/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded CI polling behavior with a safe default; no auth, secrets, or upload path changes—only fail-fast timing after flows are triggered.
> 
> **Overview**
> Adds a **`poll-timeout-seconds`** GitHub Action input (default **1800**) so jobs that trigger flows no longer poll the run-status API indefinitely when runs stay incomplete or responses stay invalid.
> 
> **`entrypoint.sh`** now validates the value as a non-negative integer, tracks elapsed time from poll start, caps sleeps to remaining budget, and **fails fast** with batch ID and last status payload when the limit is hit—including on the first status check when timeout is **0**. README and **`action.yml`** wire the input through **`POLL_TIMEOUT_SECONDS`**. Bats coverage adds an in-progress fixture and timeout / non-numeric cases (with optional sleep logging in the mock).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ecc0973fdea8289eb65fc9d9093733fbf549dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->