### PR TITLE
feat: add wait input for fire-and-forget flow runs

### DIFF
--- a/.github/workflows/integration-run-flows-nowait-staging.yml
+++ b/.github/workflows/integration-run-flows-nowait-staging.yml
@@ -1,0 +1,34 @@
+name: "Integration: Run Flows No-Wait (Staging)"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  run-flows-nowait:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Fire-and-forget: trigger flows and exit immediately without polling.
+      # The step should finish in seconds (just the trigger + initial link
+      # fetch), not wait for the flows to run on Autosana. The tight timeout
+      # is the assertion: if wait:false ever regresses to blocking, this step
+      # would poll until the flows finish and blow past the limit.
+      - name: Trigger flows without waiting (staging)
+        id: trigger
+        timeout-minutes: 2
+        uses: ./
+        with:
+          api-key: ${{ secrets.AUTOSANA_STAGING_KEY }}
+          api-url: https://staging.autosana.ai
+          platform: web
+          name: The Internet
+          app-id: the-internet
+          url: https://the-internet.herokuapp.com/
+          flow-ids: "9ae9c810-631f-472e-ba7d-9ca3b9f6820c,feeec631-bed1-43fe-ac16-ed65e4b9bd19"
+          wait: false

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ Shared optional inputs:
 - `suite-ids`: Comma-separated suite UUIDs to run after upload
 - `flow-ids`: Comma-separated flow UUIDs to run after upload
 - `web-browser`: Web only. Playwright engine to run on — `chrome` (default, real Google Chrome with proprietary codecs and DRM), `chromium` (bundled Chromium engine, no codecs / DRM), `firefox`, or `edge`. Aliases accepted: `msedge` → `edge`. Ignored for mobile.
+- `wait`: Whether to wait for triggered flows to finish and gate the job on their result. Defaults to `true`. Set to `false` to trigger the flows, print their run links, and exit immediately without blocking CI (fire-and-forget). Only applies when `suite-ids` or `flow-ids` are provided.
+
+### Fire-and-forget runs
+
+By default, when you pass `suite-ids`/`flow-ids` the action waits for the flows to finish so the job's exit code reflects the test result. To instead trigger the runs and let CI move on while tests execute on Autosana, set `wait: false`:
+
+```yaml
+- uses: autosana/autosana-ci@main
+  with:
+    api-key: ${{ secrets.AUTOSANA_KEY }}
+    platform: ios
+    bundle-id: com.example.app
+    build-path: ./build/MyApp.app
+    suite-ids: "uuid-1,uuid-2"
+    wait: false
+```
 
 Platform-specific required inputs:
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
   web-browser:
     description: "[Web] Playwright engine to run on: chrome (default, real Google Chrome with proprietary codecs / DRM), chromium (bundled engine, no codecs / DRM), firefox, or edge. Ignored for mobile platforms. Aliases accepted: msedge -> edge."
     required: false
+  wait:
+    description: "Wait for triggered flows to finish and gate the job on their result (default: true). Set to 'false' to trigger the flows, print their run links, and exit immediately without blocking CI. Only applies when suite-ids or flow-ids are provided."
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -78,3 +82,4 @@ runs:
         SUITE_IDS: ${{ inputs.suite-ids }}
         FLOW_IDS: ${{ inputs.flow-ids }}
         WEB_BROWSER: ${{ inputs.web-browser }}
+        WAIT: ${{ inputs.wait }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -509,7 +509,21 @@ echo ""
 # job) to preserve the existing contract. "false" means fire-and-forget:
 # trigger the flows, print their links, and exit 0 without polling so CI
 # isn't held open while tests run on Autosana.
+#
+# Validate up front (like web-browser above) instead of treating anything
+# that isn't exactly "false" as "true". Otherwise a typo or synonym
+# (`no`, `0`, `off`, `fals`) silently falls through to the blocking path,
+# surprising someone who deliberately asked for no-wait.
 WAIT_LOWER=$(echo "${WAIT:-true}" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+case "$WAIT_LOWER" in
+  true|false)
+    ;;
+  *)
+    echo "❌ ERROR: Unsupported 'wait' value: '$WAIT'"
+    echo "   Allowed: true (default, block on results), false (fire-and-forget)"
+    exit 1
+    ;;
+esac
 
 # Convert comma-separated IDs to JSON arrays (strip whitespace)
 if [ -n "$FLOW_IDS" ]; then
@@ -639,6 +653,7 @@ INIT_RESPONSE=$(curl -s -X GET "$API_BASE_URL/api/v1/runs/status?batch_id=$BATCH
   --max-time 30 \
   -H "X-API-Key: $AUTOSANA_KEY" || true)
 
+LINKS_PRINTED=false
 if echo "$INIT_RESPONSE" | jq empty 2>/dev/null; then
   echo "📋 Flows:"
   echo "$INIT_RESPONSE" | jq -c '.run_groups[]' 2>/dev/null | while IFS= read -r group; do
@@ -653,14 +668,22 @@ if echo "$INIT_RESPONSE" | jq empty 2>/dev/null; then
     done
   done
   echo ""
+  LINKS_PRINTED=true
 fi
 
 # Fire-and-forget: flows are triggered and running on Autosana. Don't block
-# the CI job on results — exit 0 now. The links above (and the dashboard)
-# are where users track progress.
+# the CI job on results — exit 0 now.
 if [ "$WAIT_LOWER" = "false" ]; then
   echo "🏃 Not waiting for results (wait: false)."
-  echo "   $FLOW_RUN_COUNT flow(s) are running on Autosana — track them at the links above or in the dashboard."
+  # Only point at "the links above" when we actually printed them. The
+  # initial status GET is best-effort (it can fail on a transient blip),
+  # and the blocking path tolerates that by retrying in the poll loop — but
+  # no-wait has no such retry, so don't promise links we didn't print.
+  if [ "$LINKS_PRINTED" = "true" ]; then
+    echo "   $FLOW_RUN_COUNT flow(s) are running on Autosana — track them at the links above or in the dashboard."
+  else
+    echo "   $FLOW_RUN_COUNT flow(s) are running on Autosana — track them in the dashboard (batch $BATCH_ID)."
+  fi
   exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -505,6 +505,12 @@ echo "🔬 Running Flows"
 echo "🔬 ========================================"
 echo ""
 
+# Normalize the wait flag. Default is "true" (block on results and gate the
+# job) to preserve the existing contract. "false" means fire-and-forget:
+# trigger the flows, print their links, and exit 0 without polling so CI
+# isn't held open while tests run on Autosana.
+WAIT_LOWER=$(echo "${WAIT:-true}" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+
 # Convert comma-separated IDs to JSON arrays (strip whitespace)
 if [ -n "$FLOW_IDS" ]; then
   FLOW_IDS_JSON=$(echo "$FLOW_IDS" | tr -d ' ' | tr ',' '\n' | sed '/^$/d' | jq -R . | jq -s .)
@@ -647,6 +653,15 @@ if echo "$INIT_RESPONSE" | jq empty 2>/dev/null; then
     done
   done
   echo ""
+fi
+
+# Fire-and-forget: flows are triggered and running on Autosana. Don't block
+# the CI job on results — exit 0 now. The links above (and the dashboard)
+# are where users track progress.
+if [ "$WAIT_LOWER" = "false" ]; then
+  echo "🏃 Not waiting for results (wait: false)."
+  echo "   $FLOW_RUN_COUNT flow(s) are running on Autosana — track them at the links above or in the dashboard."
+  exit 0
 fi
 
 echo "⏳ Waiting for results..."

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -46,15 +46,32 @@ setup() {
     refute_output --partial "Results Summary"
 }
 
-@test "wait=false still exits 0 even when flows would have failed" {
-    # Fire-and-forget means CI is not gated on results: a run that would fail
-    # under the blocking path must still exit 0 because we never poll it.
+@test "wait=false ignores failing flow status and still exits 0" {
+    # Fire-and-forget means CI is not gated on results. The initial status GET
+    # (best-effort, for printing links) returns a fixture where a flow has
+    # already failed — proven by the failed flow's link appearing in output —
+    # yet the action must still exit 0 and never run the pass/fail gate.
     export FLOW_IDS="uuid-1"
     export WAIT="false"
     export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_some_failed.json"
     run bash "$ENTRYPOINT"
     assert_success
+    # The failure-shaped status was actually fetched on the path we reached.
+    assert_output --partial "Checkout Flow"
+    # ...but no gating / summary logic ran.
+    assert_output --partial "Not waiting for results (wait: false)"
     refute_output --partial "did not pass"
+    refute_output --partial "Results Summary"
+}
+
+@test "invalid wait value fails fast with a clear error" {
+    export FLOW_IDS="uuid-1"
+    export WAIT="nope"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Unsupported 'wait' value"
+    # Must not have triggered flows with a bad config.
+    refute_output --partial "Triggering flows"
 }
 
 @test "wait flag is case-insensitive (False)" {

--- a/tests/flow_execution.bats
+++ b/tests/flow_execution.bats
@@ -32,6 +32,49 @@ setup() {
     assert_output --partial "Running Flows"
 }
 
+# --- No-wait (fire-and-forget) mode ---
+
+@test "wait=false triggers flows then exits 0 without polling for results" {
+    export FLOW_IDS="uuid-1"
+    export WAIT="false"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "Triggered"
+    assert_output --partial "Not waiting for results (wait: false)"
+    # It must NOT enter the polling loop or print a results summary.
+    refute_output --partial "Waiting for results..."
+    refute_output --partial "Results Summary"
+}
+
+@test "wait=false still exits 0 even when flows would have failed" {
+    # Fire-and-forget means CI is not gated on results: a run that would fail
+    # under the blocking path must still exit 0 because we never poll it.
+    export FLOW_IDS="uuid-1"
+    export WAIT="false"
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_some_failed.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    refute_output --partial "did not pass"
+}
+
+@test "wait flag is case-insensitive (False)" {
+    export FLOW_IDS="uuid-1"
+    export WAIT="False"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "Not waiting for results (wait: false)"
+}
+
+@test "wait defaults to blocking when unset" {
+    export FLOW_IDS="uuid-1"
+    unset WAIT
+    export MOCK_POLL_RESPONSE_FILE="$PROJECT_ROOT/tests/fixtures/poll_all_passed.json"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "Waiting for results..."
+    assert_output --partial "All flows passed"
+}
+
 # --- run-flows API errors ---
 
 @test "run-flows API returns HTTP 500" {

--- a/tests/test_helper/common-setup.bash
+++ b/tests/test_helper/common-setup.bash
@@ -24,6 +24,9 @@ _common_setup() {
     export VARIABLES=""
     export SUITE_IDS=""
     export FLOW_IDS=""
+    # Default to the blocking (wait) behavior so existing tests assert on the
+    # full poll + summary path. No-wait tests override this explicitly.
+    export WAIT="true"
     # Initialize WEB_BROWSER explicitly so a stray value in the outer shell
     # (developer's local env, CI runner inheriting from a parent process)
     # doesn't leak into tests that don't override it. Validation in


### PR DESCRIPTION
## Summary

- Adds a `wait` input to the action (default `true`, preserving current behavior).
- When `wait: false`, the action triggers the flows, prints their run links, and exits `0` immediately — without polling run status. This lets customers upload + trigger and offload test execution to Autosana without keeping the CI job running the whole time.
- Only applies when `suite-ids`/`flow-ids` are provided. The blocking path (poll until complete, gate exit code on results) is unchanged.

Closes AUT-1421. Requested in [Slack](https://autosana.slack.com/archives/C0AR084NPGR/p1780665409481289?thread_ts=1778146278.859569&cid=C0AR084NPGR) — customer expected the job to upload and offload execution, but it kept CI running while tests executed.

## Changes

- `action.yml`: new `wait` input, passed to the entrypoint as `WAIT`.
- `entrypoint.sh`: normalize `WAIT`; after triggering flows and printing run links, exit `0` when `wait=false` instead of entering the poll loop.
- `README.md`: document `wait` + a fire-and-forget example.
- `tests/`: 4 new bats cases (no-wait exits 0 without polling, still 0 when flows would fail, case-insensitive, defaults to blocking).

## Test plan

- [x] `make test` — all 81 tests pass (run `tests/setup.sh` first to install bats helpers).
- [ ] Smoke test in a real workflow with `wait: false` to confirm the job exits right after the run links print.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `wait` input (default: `true`) to control whether CI blocks on triggered flow results
  * Enabled "fire-and-forget" runs when `wait` is set to `false`, allowing immediate exit after triggering flows

* **Documentation**
  * Updated documentation with "Fire-and-forget runs" section and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->