### PR TITLE
AUT-1287: add code-sync mode for repo-stored flows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   platform:
     description: "Platform: android, ios, or web"
-    required: true
+    required: false
 
   # Mobile-specific inputs (required when platform is android or ios)
   bundle-id:
@@ -42,6 +42,20 @@ inputs:
     description: "Key-value variables to pass to flow instructions (format: KEY1=VALUE1,KEY2=VALUE2)"
     required: false
 
+  # Code-managed flow sync inputs
+  code-sync:
+    description: "Code-managed flow sync mode: off, plan, or import"
+    required: false
+    default: "off"
+  code-sync-path:
+    description: "Path to the Autosana config folder"
+    required: false
+    default: ".autosana"
+  code-sync-fail-on-conflict:
+    description: "Fail the workflow when code sync reports conflicts"
+    required: false
+    default: "true"
+
   # Flow execution inputs (optional - provide to run flows after upload)
   suite-ids:
     description: "Comma-separated suite UUIDs to run (e.g., 'uuid1,uuid2')"
@@ -61,6 +75,10 @@ runs:
   steps:
     - run: chmod +x ${{ github.action_path }}/entrypoint.sh
       shell: bash
+    - name: Install Autosana CLI
+      if: ${{ inputs.code-sync != 'off' }}
+      run: python -m pip install --upgrade autosana
+      shell: bash
     - run: ${{ github.action_path }}/entrypoint.sh
       shell: bash
       env:
@@ -78,6 +96,9 @@ runs:
         AUTOSANA_API_URL: ${{ inputs.api-url }}
         # Build variables
         VARIABLES: ${{ inputs.variables }}
+        CODE_SYNC: ${{ inputs.code-sync }}
+        CODE_SYNC_PATH: ${{ inputs.code-sync-path }}
+        CODE_SYNC_FAIL_ON_CONFLICT: ${{ inputs.code-sync-fail-on-conflict }}
         # Flow execution
         SUITE_IDS: ${{ inputs.suite-ids }}
         FLOW_IDS: ${{ inputs.flow-ids }}

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
       shell: bash
     - name: Install Autosana CLI
       if: ${{ inputs.code-sync != 'off' }}
-      run: python -m pip install --upgrade autosana
+      run: python3 -m pip install --upgrade autosana
       shell: bash
     - run: ${{ github.action_path }}/entrypoint.sh
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,13 @@ echo ""
 # API Base URL - can be overridden for testing (staging, ngrok, etc.)
 # Default: production
 API_BASE_URL="${AUTOSANA_API_URL:-https://backend.autosana.ai}"
+CODE_SYNC="${CODE_SYNC:-off}"
+CODE_SYNC_PATH="${CODE_SYNC_PATH:-.autosana}"
+CODE_SYNC_FAIL_ON_CONFLICT="${CODE_SYNC_FAIL_ON_CONFLICT:-true}"
 echo "🌐 API Base URL: $API_BASE_URL"
 echo "🎯 Platform: $PLATFORM"
 echo "🏷️  Environment: ${ENVIRONMENT:-<default>}"
+echo "🔁 Code sync: $CODE_SYNC"
 echo ""
 
 # Redact sensitive fields from payloads before logging
@@ -22,15 +26,22 @@ _redact_payload() {
 }
 
 # Check common required inputs
-if [ -z "$AUTOSANA_KEY" ] || [ -z "$PLATFORM" ]; then
+if [ -z "$AUTOSANA_KEY" ] || { [ -z "$PLATFORM" ] && [ "$CODE_SYNC" = "off" ]; }; then
   echo "❌ ERROR: Missing required inputs."
   echo "   - AUTOSANA_KEY: ${AUTOSANA_KEY:+SET}${AUTOSANA_KEY:-NOT SET}"
   echo "   - PLATFORM: ${PLATFORM:+SET}${PLATFORM:-NOT SET}"
   exit 1
 fi
 
+if ! echo "$CODE_SYNC" | grep -qE '^(off|plan|import)$'; then
+  echo "❌ ERROR: Invalid code-sync '$CODE_SYNC'. Must be off, plan, or import."
+  exit 1
+fi
+
 # Validate platform and check platform-specific inputs
-if [ "$PLATFORM" = "web" ]; then
+if [ -z "$PLATFORM" ]; then
+  echo "🔁 Sync-only workflow detected"
+elif [ "$PLATFORM" = "web" ]; then
   echo "🌐 Web platform detected"
   echo "🔍 Checking web-specific environment variables..."
   echo "   AUTOSANA_KEY: ${AUTOSANA_KEY:0:10}... (${#AUTOSANA_KEY} chars)"
@@ -151,6 +162,48 @@ echo "   COMMIT_SHA: ${COMMIT_SHA:-not set}"
 echo "   BRANCH_NAME: ${BRANCH_NAME:-not set}"
 echo "   REPO_FULL_NAME: ${REPO_FULL_NAME:-not set}"
 echo ""
+
+run_code_sync() {
+  if [ "$CODE_SYNC" = "off" ]; then
+    return 0
+  fi
+
+  if ! command -v autosana >/dev/null 2>&1; then
+    echo "❌ ERROR: autosana CLI is required for code sync but was not found."
+    exit 1
+  fi
+
+  echo "🔁 Running Autosana code sync: $CODE_SYNC"
+  echo "   Path: $CODE_SYNC_PATH"
+  echo "   Commit SHA: ${COMMIT_SHA:-not set}"
+  echo "   Branch: ${BRANCH_NAME:-not set}"
+  echo "   Repository: ${REPO_FULL_NAME:-not set}"
+  echo ""
+
+  ARGS=(sync "$CODE_SYNC" --path "$CODE_SYNC_PATH" --api-url "$API_BASE_URL" --api-key "$AUTOSANA_KEY")
+  if [ -n "$REPO_FULL_NAME" ]; then
+    ARGS+=(--repo-full-name "$REPO_FULL_NAME")
+  fi
+  if [ -n "$COMMIT_SHA" ]; then
+    ARGS+=(--commit-sha "$COMMIT_SHA")
+  fi
+  if [ -n "$BRANCH_NAME" ]; then
+    ARGS+=(--branch-name "$BRANCH_NAME")
+  fi
+  if [ "$CODE_SYNC_FAIL_ON_CONFLICT" != "true" ]; then
+    ARGS+=(--no-fail-on-conflict)
+  fi
+
+  autosana "${ARGS[@]}"
+  echo ""
+}
+
+run_code_sync
+
+if [ -z "$PLATFORM" ]; then
+  echo "✅ Code sync complete."
+  exit 0
+fi
 
 # ============================================================
 # WEB PLATFORM FLOW
@@ -823,4 +876,3 @@ else
   fi
   exit 1
 fi
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,19 @@ if ! echo "$CODE_SYNC" | grep -qE '^(off|plan|import)$'; then
   exit 1
 fi
 
+# Normalize and validate the fail-on-conflict boolean so a typo like "treu"
+# or "TRUE" can't silently flip to the unsafe --no-fail-on-conflict default.
+CODE_SYNC_FAIL_ON_CONFLICT_LOWER=$(echo "${CODE_SYNC_FAIL_ON_CONFLICT:-true}" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+case "$CODE_SYNC_FAIL_ON_CONFLICT_LOWER" in
+  true|false)
+    ;;
+  *)
+    echo "❌ ERROR: Unsupported 'code-sync-fail-on-conflict' value: '$CODE_SYNC_FAIL_ON_CONFLICT'"
+    echo "   Allowed: true (default), false"
+    exit 1
+    ;;
+esac
+
 # Validate platform and check platform-specific inputs
 if [ -z "$PLATFORM" ]; then
   echo "🔁 Sync-only workflow detected"
@@ -180,7 +193,7 @@ run_code_sync() {
   echo "   Repository: ${REPO_FULL_NAME:-not set}"
   echo ""
 
-  ARGS=(sync "$CODE_SYNC" --path "$CODE_SYNC_PATH" --api-url "$API_BASE_URL" --api-key "$AUTOSANA_KEY")
+  ARGS=(sync "$CODE_SYNC" --path "$CODE_SYNC_PATH" --api-url "$API_BASE_URL")
   if [ -n "$REPO_FULL_NAME" ]; then
     ARGS+=(--repo-full-name "$REPO_FULL_NAME")
   fi
@@ -190,11 +203,14 @@ run_code_sync() {
   if [ -n "$BRANCH_NAME" ]; then
     ARGS+=(--branch-name "$BRANCH_NAME")
   fi
-  if [ "$CODE_SYNC_FAIL_ON_CONFLICT" != "true" ]; then
+  if [ "$CODE_SYNC_FAIL_ON_CONFLICT_LOWER" != "true" ]; then
     ARGS+=(--no-fail-on-conflict)
   fi
 
-  autosana "${ARGS[@]}"
+  # Pass the API key via env, not argv: argv is readable by concurrent
+  # processes on shared runners (/proc/<pid>/cmdline), matching how the
+  # curl calls in this script keep the key in a header.
+  AUTOSANA_API_KEY="$AUTOSANA_KEY" autosana "${ARGS[@]}"
   echo ""
 }
 

--- a/tests/code_sync.bats
+++ b/tests/code_sync.bats
@@ -64,6 +64,34 @@ setup() {
     assert_output --partial "--no-fail-on-conflict"
 }
 
+@test "code-sync fail-on-conflict normalizes case" {
+    export CODE_SYNC_FAIL_ON_CONFLICT="FALSE"
+
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    run cat "$MOCK_AUTOSANA_LOG"
+    assert_output --partial "--no-fail-on-conflict"
+}
+
+@test "code-sync rejects invalid fail-on-conflict value" {
+    export CODE_SYNC_FAIL_ON_CONFLICT="treu"
+
+    run bash "$ENTRYPOINT"
+
+    assert_failure
+    assert_output --partial "Unsupported 'code-sync-fail-on-conflict' value"
+}
+
+@test "code-sync passes API key via env not argv" {
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    run cat "$MOCK_AUTOSANA_LOG"
+    refute_output --partial "--api-key"
+    assert_output --partial "env-api-key=test-api-key-1234567890"
+}
+
 @test "upload-only web workflow does not call CLI" {
     export PLATFORM="web"
     export CODE_SYNC="off"

--- a/tests/code_sync.bats
+++ b/tests/code_sync.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+    export PLATFORM=""
+    export CODE_SYNC="plan"
+    export CODE_SYNC_PATH=".autosana"
+    export CODE_SYNC_FAIL_ON_CONFLICT="true"
+    export MOCK_AUTOSANA_LOG="$BATS_TEST_TMPDIR/autosana.log"
+}
+
+@test "code-sync plan can run without platform" {
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    assert_output --partial "Sync-only workflow detected"
+    assert_output --partial "Code sync complete"
+    run cat "$MOCK_AUTOSANA_LOG"
+    assert_output --partial "sync plan"
+    assert_output --partial "--path .autosana"
+    assert_output --partial "--repo-full-name myorg/myrepo"
+    assert_output --partial "--commit-sha fakegitsha1234567890"
+    assert_output --partial "--branch-name main"
+}
+
+@test "pull request event uses PR head SHA" {
+    export GITHUB_EVENT_PATH="$PROJECT_ROOT/tests/fixtures/github_event_pr.json"
+
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    run cat "$MOCK_AUTOSANA_LOG"
+    assert_output --partial "--commit-sha pr-head-sha-abcdef123456"
+}
+
+@test "push event falls back to git HEAD" {
+    export GITHUB_EVENT_PATH="$PROJECT_ROOT/tests/fixtures/github_event_push.json"
+
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    run cat "$MOCK_AUTOSANA_LOG"
+    assert_output --partial "--commit-sha fakegitsha1234567890"
+}
+
+@test "code-sync import calls CLI import command" {
+    export CODE_SYNC="import"
+
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    run cat "$MOCK_AUTOSANA_LOG"
+    assert_output --partial "sync import"
+}
+
+@test "code-sync can opt out of conflict failure" {
+    export CODE_SYNC_FAIL_ON_CONFLICT="false"
+
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    run cat "$MOCK_AUTOSANA_LOG"
+    assert_output --partial "--no-fail-on-conflict"
+}
+
+@test "upload-only web workflow does not call CLI" {
+    export PLATFORM="web"
+    export CODE_SYNC="off"
+    export APP_ID="my-app"
+    export URL="https://example.com"
+
+    run bash "$ENTRYPOINT"
+
+    assert_success
+    assert_output --partial "Web URL registered successfully"
+    [ ! -f "$MOCK_AUTOSANA_LOG" ]
+}

--- a/tests/input_validation.bats
+++ b/tests/input_validation.bats
@@ -16,6 +16,7 @@ setup() {
 
 @test "missing PLATFORM exits 1" {
     unset PLATFORM
+    export CODE_SYNC="off"
     run bash "$ENTRYPOINT"
     assert_failure
     assert_output --partial "Missing required inputs"
@@ -24,9 +25,26 @@ setup() {
 @test "both AUTOSANA_KEY and PLATFORM missing exits 1" {
     unset AUTOSANA_KEY
     unset PLATFORM
+    export CODE_SYNC="off"
     run bash "$ENTRYPOINT"
     assert_failure
     assert_output --partial "Missing required inputs"
+}
+
+@test "missing PLATFORM is valid for code sync" {
+    unset PLATFORM
+    export CODE_SYNC="plan"
+    export MOCK_AUTOSANA_LOG="$BATS_TEST_TMPDIR/autosana.log"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "Sync-only workflow detected"
+}
+
+@test "invalid code-sync exits 1" {
+    export CODE_SYNC="destroy"
+    run bash "$ENTRYPOINT"
+    assert_failure
+    assert_output --partial "Invalid code-sync"
 }
 
 # --- Invalid platform ---

--- a/tests/mocks/autosana
+++ b/tests/mocks/autosana
@@ -7,4 +7,5 @@ if [ -n "$MOCK_AUTOSANA_FAIL" ]; then
 fi
 
 echo "$*" >> "${MOCK_AUTOSANA_LOG:-/tmp/autosana-mock.log}"
+echo "env-api-key=${AUTOSANA_API_KEY:-unset}" >> "${MOCK_AUTOSANA_LOG:-/tmp/autosana-mock.log}"
 echo "Autosana CLI mock: $*"

--- a/tests/mocks/autosana
+++ b/tests/mocks/autosana
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -n "$MOCK_AUTOSANA_FAIL" ]; then
+  echo "autosana mock failure" >&2
+  exit 1
+fi
+
+echo "$*" >> "${MOCK_AUTOSANA_LOG:-/tmp/autosana-mock.log}"
+echo "Autosana CLI mock: $*"


### PR DESCRIPTION
## Summary

Adds a code-managed flow sync mode to the action, pairing with backend PR Autosana/AutosanaBackend#908 (AUT-1287, code-managed flows V1).

- New inputs: `code-sync` (off | plan | import), `code-sync-path` (default `.autosana`), `code-sync-fail-on-conflict` (default true)
- When enabled, installs the Autosana CLI and runs `autosana sync plan` / `autosana sync import` against the checked-out commit, so flow files in the repo are validated (plan) or imported commit-pinned (import)
- Sync-only mode works without a `platform` input; existing upload/run workflows are unchanged when `code-sync` is off

Linear: https://linear.app/autosana/issue/AUT-1287

## Test plan

- [x] Full bats suite passes locally: 90/90 including new `tests/code_sync.bats` with a mocked `autosana` CLI
- [x] `bash -n entrypoint.sh` syntax check
- [x] Rebased on main; kept the new exit-status logic and `variables` input intact

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes required-input rules and runs pip-installed CLI against the API with commit-pinned imports; default upload paths stay off when code-sync is off.
> 
> **Overview**
> Adds **code-managed flow sync** to the GitHub Action so CI can run `autosana sync plan` or `sync import` against repo flow files (default `.autosana`) before or instead of app upload.
> 
> New inputs: `code-sync` (`off` | `plan` | `import`), `code-sync-path`, and `code-sync-fail-on-conflict`. When sync is not `off`, the action **installs the Autosana CLI** and the entrypoint invokes sync with **repo, branch, and commit** (PR head SHA on `pull_request` events). The API key is passed via **`AUTOSANA_API_KEY` env**, not CLI argv. Invalid `code-sync` or `code-sync-fail-on-conflict` values fail fast (typos no longer silently disable fail-on-conflict).
> 
> **`platform` is now optional** when `code-sync` is enabled: sync-only jobs can omit platform and exit after sync. Upload/run behavior is unchanged when `code-sync` is `off`.
> 
> Bats coverage adds `tests/code_sync.bats` and a mocked `autosana` CLI; input validation tests were updated for the new rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf618a2286c98fc98c07a208fdb0a35d3fca731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key is now optional, enabling code synchronization-only workflows without platform credentials
  * Added configurable code synchronization with three new settings: operational mode (plan/import), custom output path, and conflict-failure behavior

* **Improvements**
  * Enhanced input validation and execution logic for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->