### PR TITLE
feat: support iOS .ipa (real-device) uploads

### DIFF
--- a/.github/workflows/integration-upload-ios-ipa-prod.yml
+++ b/.github/workflows/integration-upload-ios-ipa-prod.yml
@@ -1,0 +1,52 @@
+name: "Integration: Upload iOS IPA (Prod)"
+
+# Smoke test for the real-device (.ipa) upload path. Builds a minimal synthetic
+# .ipa (a Payload/.app bundle zipped) and uploads it through the action. The
+# action exits non-zero if start-upload / upload / confirm fail, so a green run
+# proves a .ipa flows cleanly through the action and API end to end.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build synthetic .ipa
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p Payload/IpaSmoke.app
+          cat > Payload/IpaSmoke.app/Info.plist <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleIdentifier</key><string>com.vibetest.ipasmoke</string>
+            <key>CFBundleName</key><string>IpaSmoke</string>
+            <key>CFBundleExecutable</key><string>IpaSmoke</string>
+            <key>CFBundleVersion</key><string>1</string>
+            <key>CFBundleShortVersionString</key><string>1.0</string>
+          </dict>
+          </plist>
+          PLIST
+          printf '\x00' > Payload/IpaSmoke.app/IpaSmoke
+          zip -r -q smoke.ipa Payload
+          test -s smoke.ipa
+          echo "Built $(ls -lh smoke.ipa | awk '{print $5}') smoke.ipa"
+
+      - name: Upload to Autosana (prod)
+        uses: ./
+        with:
+          api-key: ${{ secrets.AUTOSANA_KEY }}
+          name: IPA Smoke Test
+          bundle-id: com.vibetest.ipasmoke
+          platform: ios
+          build-path: smoke.ipa

--- a/.github/workflows/integration-upload-ios-ipa-staging.yml
+++ b/.github/workflows/integration-upload-ios-ipa-staging.yml
@@ -1,0 +1,53 @@
+name: "Integration: Upload iOS IPA (Staging)"
+
+# Smoke test for the real-device (.ipa) upload path. Builds a minimal synthetic
+# .ipa (a Payload/.app bundle zipped) and uploads it through the action. The
+# action exits non-zero if start-upload / upload / confirm fail, so a green run
+# proves a .ipa flows cleanly through the action and API end to end.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build synthetic .ipa
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p Payload/IpaSmoke.app
+          cat > Payload/IpaSmoke.app/Info.plist <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleIdentifier</key><string>com.vibetest.ipasmoke</string>
+            <key>CFBundleName</key><string>IpaSmoke</string>
+            <key>CFBundleExecutable</key><string>IpaSmoke</string>
+            <key>CFBundleVersion</key><string>1</string>
+            <key>CFBundleShortVersionString</key><string>1.0</string>
+          </dict>
+          </plist>
+          PLIST
+          printf '\x00' > Payload/IpaSmoke.app/IpaSmoke
+          zip -r -q smoke.ipa Payload
+          test -s smoke.ipa
+          echo "Built $(ls -lh smoke.ipa | awk '{print $5}') smoke.ipa"
+
+      - name: Upload to Autosana (staging)
+        uses: ./
+        with:
+          api-key: ${{ secrets.AUTOSANA_STAGING_KEY }}
+          api-url: https://staging.autosana.ai
+          name: IPA Smoke Test
+          bundle-id: com.vibetest.ipasmoke
+          platform: ios
+          build-path: smoke.ipa

--- a/README.md
+++ b/README.md
@@ -13,6 +13,30 @@ CI integration to upload new builds and trigger flows from GitHub workflows.
     build-path: build/app/outputs/flutter-apk/app-release.apk
 ```
 
+## iOS usage
+
+```yaml
+# Simulator build (zipped .app)
+- uses: autosana/autosana-ci@main
+  with:
+    api-key: ${{ secrets.AUTOSANA_KEY }}
+    platform: ios
+    bundle-id: com.example.app
+    build-path: build/MyApp.app.zip
+
+# Real-device build (.ipa) — required to run on physical devices
+- uses: autosana/autosana-ci@main
+  with:
+    api-key: ${{ secrets.AUTOSANA_KEY }}
+    platform: ios
+    bundle-id: com.example.app
+    build-path: build/MyApp.ipa
+```
+
+Upload the artifact with its real extension — don't re-zip a `.ipa`. The
+extension determines the target: a `.ipa` runs on **real devices**, while a
+zipped `.app` bundle (`.zip`) runs on the **iOS simulator**.
+
 ## Web usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "[Mobile] Your app's bundle ID"
     required: false
   build-path:
-    description: "[Mobile] Full path to the .apk/.app file"
+    description: "[Mobile] Full path to the build artifact. Android: .apk or .aab. iOS: .ipa (real-device build) or a zipped .app bundle (.zip, simulator build)."
     required: false
 
   # Web-specific inputs (required when platform is web)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -248,6 +248,19 @@ echo "   Original BUILD_PATH: $BUILD_PATH"
 echo "   Extracted FILENAME: $FILENAME"
 echo "   File size: $(ls -lh "$BUILD_PATH" 2>/dev/null | awk '{print $5}' || echo 'File not found')"
 echo "   File permissions: $(ls -la "$BUILD_PATH" 2>/dev/null | awk '{print $1}' || echo 'File not found')"
+
+# Surface which iOS target this artifact maps to. The backend derives the
+# stored extension from the filename: .ipa -> real device, a zipped .app -> simulator.
+# A device build must be a .ipa; a re-zipped .ipa (.zip) is treated as a
+# simulator build and won't run on real devices.
+case "$(echo "$PLATFORM" | tr '[:upper:]' '[:lower:]')" in
+  ios*)
+    case "$(echo "$FILENAME" | tr '[:upper:]' '[:lower:]')" in
+      *.ipa) echo "   iOS build type: real device (.ipa)" ;;
+      *)     echo "   iOS build type: simulator (zipped .app). Upload a .ipa to test on physical devices." ;;
+    esac
+    ;;
+esac
 echo ""
 
 echo "🎯 Starting upload for $FILENAME (from $BUILD_PATH) to Autosana..."

--- a/tests/fixtures/dummy.app.zip
+++ b/tests/fixtures/dummy.app.zip
@@ -1,0 +1,1 @@
+dummy zip

--- a/tests/fixtures/dummy.ipa
+++ b/tests/fixtures/dummy.ipa
@@ -1,0 +1,1 @@
+dummy ipa

--- a/tests/mobile_platform.bats
+++ b/tests/mobile_platform.bats
@@ -19,6 +19,30 @@ setup() {
     assert_output --partial "Upload completed successfully"
 }
 
+@test "ios .ipa is reported as a real-device build" {
+    export PLATFORM="ios"
+    export BUILD_PATH="$PROJECT_ROOT/tests/fixtures/dummy.ipa"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "iOS build type: real device (.ipa)"
+    assert_output --partial "Upload completed successfully"
+}
+
+@test "ios zipped .app is reported as a simulator build" {
+    export PLATFORM="ios"
+    export BUILD_PATH="$PROJECT_ROOT/tests/fixtures/dummy.app.zip"
+    run bash "$ENTRYPOINT"
+    assert_success
+    assert_output --partial "iOS build type: simulator"
+    assert_output --partial "Upload a .ipa to test on physical devices"
+}
+
+@test "android upload does not print iOS build type" {
+    run bash "$ENTRYPOINT"
+    assert_success
+    refute_output --partial "iOS build type"
+}
+
 @test "start-upload returns HTTP 500" {
     export MOCK_CURL_STATUS_START_UPLOAD=500
     run bash "$ENTRYPOINT"


### PR DESCRIPTION
Part of AUT-1502 (upload-side prerequisite; execution-target inputs + suite.yml are still open on the ticket).

## Summary

Enables real-device iOS testing through the GitHub Action by treating a `.ipa` as a first-class build artifact.

- **`action.yml`**: `build-path` now documents the full set of accepted artifacts — Android `.apk`/`.aab`, iOS `.ipa` (real device) or zipped `.app` (`.zip`, simulator).
- **`entrypoint.sh`**: adds an informational log that reports which target an iOS artifact maps to (`real device (.ipa)` vs `simulator (zipped .app)`) and nudges users toward a `.ipa` for physical-device runs.
- **`README.md`**: adds an iOS usage section with both simulator and real-device examples, and a note not to re-zip a `.ipa`.
- **tests**: new bats coverage for `.ipa` → real-device and zipped `.app` → simulator, plus `.ipa`/`.app.zip` fixtures.

The upload flow itself is unchanged — the action already forwards the artifact's real filename to the API. The actual fix is server-side (the upload endpoint used to force every iOS build to `.zip`): Autosana/AutosanaBackend#994. This PR makes the Action advertise and surface `.ipa` so the end-to-end path is usable.

## Why

CI-driven customers (e.g. Wallbit) had no way to get a real-device build onto the platform: the backend stored every iOS upload as `.zip` (→ simulator), and the run-time guard requires a `.ipa` for `physical_device` runs. Backend PR #994 fixes the storage side; this aligns the Action.

## Test plan

- [x] `bats tests/*.bats` passes (full suite green, incl. 3 new mobile tests)
- [ ] Merge after backend #994 deploys; then run the `integration-upload-ios-*` workflow with a real `.ipa` end-to-end

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for iOS build types to distinguish between real-device and simulator builds.

* **Documentation**
  * Added comprehensive iOS usage section with GitHub Actions examples for real-device and simulator deployments.
  * Clarified artifact format requirements: `.ipa` for real devices, zipped `.app` bundles for simulators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->